### PR TITLE
strip git tags with slashes to their last component

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -68,8 +68,10 @@ for PKG_PATH in $(catkin_topological_order --only-folders); do
     exit 0
   fi
 
-  # Set the version
-  sed -i "1 s/([^)]*)/($(git describe --tag || echo 0)-$(date +%Y.%m.%d.%H.%M))/" debian/changelog
+  # Set the version based on the checked out tag
+  # git tags with slashes will be reduced to their last component for convenience
+  # as release versions should not contain '/' anyway
+  sed -i "1 s@([^)]*)@($(git describe --tag | sed 's@.*/@@' || echo 0)-$(date +%Y.%m.%d.%H.%M))@" debian/changelog
 
   # https://github.com/ros-infrastructure/bloom/pull/643
   echo 11 > debian/compat


### PR DESCRIPTION
Skirt around this unnecessary error when building bloom release repositories:

199926 2023-01-11T18:56:21.9436503Z + sed -i 1 s/([^)]*)/(release/noetic/stage/4.3.0-1-2023.01.11.18.56)/ debian/changelog 199927 2023-01-11T18:56:21.9447938Z sed: -e expression #1, char 22: unknown option to `s'

...

Yes, I know we shouldn't build release repositories and they should not even exist, but it's also unnecessary to have it fail for syntactic reasons when the fix is trivial. :)