### PR TITLE
Add -y to add-apt-repository

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -5,7 +5,7 @@ set -ex
 
 echo "Install dependencies"
 
-sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/sbuild
+sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/sbuild
 sudo apt update
 sudo apt install -y mmdebstrap distro-info debian-archive-keyring ccache curl vcstool python3-rosdep2 sbuild catkin python3-bloom
 


### PR DESCRIPTION
This is useful when running this action via https://github.com/nektos/act to avoid add-apt-repository prompting for confirmation