### PR TITLE
fix test sources.repos file

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,6 @@ inputs:
   REPOS_FILE:
     description: Repos file with list of repositories to package.
     required: false
-    default: sources.repos
   SBUILD_CONF:
     description: Additional sbuild.conf lines. For example EXTRA_REPOSITORIES,
       or VERBOSE. See man sbuild.conf.

--- a/prepare
+++ b/prepare
@@ -58,7 +58,9 @@ $verbose = 1;
 EOF
 echo "$SBUILD_CONF" >> "$HOME/.sbuildrc"
 
-test "$REPOS_FILE" = "sources.repos" -a ! -f "$REPOS_FILE" && exit
+
+REPOS_FILE=${REPOS_FILE:-sources.repos}
+test ! -f "$REPOS_FILE" && exit
 
 echo "Checkout workspace"
 

--- a/prepare
+++ b/prepare
@@ -59,7 +59,7 @@ EOF
 echo "$SBUILD_CONF" >> "$HOME/.sbuildrc"
 
 
-REPOS_FILE=${REPOS_FILE:-sources.repos}
+REPOS_FILE="${REPOS_FILE:-sources.repos}"
 test ! -f "$REPOS_FILE" && exit
 
 echo "Checkout workspace"


### PR DESCRIPTION
`test "$REPOS_FILE" = "sources.repos" -a ! -f "$REPOS_FILE" && exit`

If `$REPOS_FILE` is not set or has a different value than `sources.repos` but the file does not exist this should exit and currently isn't, right?

It looks like the check for the file exists is needed whether the file is called `sources.repos` or not, or maybe I'm not understanding something...