### PR TITLE
Add support for git-lfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ For example, if you are deploying a static site with lots of binary artifacts, t
 ## ``PACKAGES_BRANCH``
 If set, this branch will be used to push the packages instead of `DEB_DISTRO-ROS_DISTRO`.
 
+## ``GIT_LFS``
+
+If set to true, Git Large File Storage will be used to store the generated binaries.
+
 ## Example usage
 
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -37,6 +37,9 @@ inputs:
   PACKAGES_BRANCH:
     description: If set, this branch will be used to push the packages instead of DEB_DISTRO-ROS_DISTRO.
     required: false
+  GIT_LFS:
+    description: If set to true, use Git Large File Storage for storing binaries (*.deb and *.ddeb)
+    required: false
 runs:
   using: composite
   steps:
@@ -72,3 +75,4 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         SQUASH_HISTORY: ${{ inputs.SQUASH_HISTORY }}
         PACKAGES_BRANCH: ${{ inputs.PACKAGES_BRANCH }}
+        GIT_LFS: ${{ inputs.GIT_LFS }}

--- a/prepare
+++ b/prepare
@@ -26,14 +26,15 @@ set -ex
 # TODO: drop once new distros are available
 test "$(lsb_release -cs)" = "jammy" && sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/sbuild
 sudo apt update
+
 # Try different package combinations:
 # first is for a clean jammy with the PPA
 # second is for Debian bookworm and newer
 # third is for OSRF package names
 # TODO: get OSRF to add proper package relations
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap vcstool python3-rosdep2 catkin python3-bloom curl apt-cacher-ng || \
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap vcstool python3-rosdep2 colcon python3-colcon-package-information python3-colcon-ros python3-bloom curl apt-cacher-ng || \
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap python3-vcstool python3-rosdep python3-colcon-cmake python3-colcon-installed-package-information python3-colcon-library-path python3-colcon-package-information python3-colcon-pkg-config python3-colcon-recursive-crawl python3-colcon-test-result python3-bloom curl apt-cacher-ng
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap vcstool python3-rosdep2 catkin python3-bloom curl apt-cacher-ng git-lfs || \
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap vcstool python3-rosdep2 colcon python3-colcon-package-information python3-colcon-ros python3-bloom curl apt-cacher-ng git-lfs || \
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap python3-vcstool python3-rosdep python3-colcon-cmake python3-colcon-installed-package-information python3-colcon-library-path python3-colcon-package-information python3-colcon-pkg-config python3-colcon-recursive-crawl python3-colcon-test-result python3-bloom curl apt-cacher-ng git-lfs
 
 echo "Setup build environment"
 

--- a/repository
+++ b/repository
@@ -38,13 +38,16 @@ test -n "$GITHUB_TOKEN" && find . -type f -size +100M -delete
 REPOSITORY="$(printf "%s" "$GITHUB_REPOSITORY" | tr / _)"
 BRANCH="${PACKAGES_BRANCH:-$DEB_DISTRO-$ROS_DISTRO}"
 echo '```bash' > README.md
-echo "echo \"deb [trusted=yes] https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY.list" >> README.md
-echo "echo \"yaml https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$BRANCH/local.yaml $ROS_DISTRO\" | sudo tee /etc/ros/rosdep/sources.list.d/1-$REPOSITORY.list" >> README.md
+echo "echo \"deb [trusted=yes] https://github.com/$GITHUB_REPOSITORY/raw/$BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY.list" >> README.md
+echo "echo \"yaml https://github.com/$GITHUB_REPOSITORY/raw/$BRANCH/local.yaml $ROS_DISTRO\" | sudo tee /etc/ros/rosdep/sources.list.d/1-$REPOSITORY.list" >> README.md
 echo '```' >> README.md
 
 test -z "$GITHUB_TOKEN" && exit
 
 git init -b "$BRANCH"
+
+test -n "$GIT_LFS" && git lfs track "*.deb" "*.ddeb"
+
 git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 if [ "$SQUASH_HISTORY" != "true" ]; then
   git fetch origin "$BRANCH" && git reset --soft FETCH_HEAD || true


### PR DESCRIPTION
This PR adds support for using `git-lfs` to store the generated binaries. A new option is added (`GIT_LFS`), which is set to `false` by default and it's entirely optional.