### PR TITLE
Allow users to set the branch where the packages will be pushed to

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Set to `${{ secrets.GITHUB_TOKEN }}` to deploy to a `DEB_DISTRO-ROS_DISTRO` bran
 If set to true, all previous commits on the target branch will be discarded.
 For example, if you are deploying a static site with lots of binary artifacts, this can help prevent the repository from becoming overly bloated
 
+## ``PACKAGES_BRANCH``
+If set, this branch will be used to push the packages instead of `DEB_DISTRO-ROS_DISTRO`.
+
 ## Example usage
 
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -34,6 +34,9 @@ inputs:
     description: If set to true, all previous commits on the target branch will be discarded.
     required: false
     default: false
+  PACKAGES_BRANCH:
+    description: If set, this branch will be used to push the packages instead of DEB_DISTRO-ROS_DISTRO.
+    required: false
 runs:
   using: composite
   steps:
@@ -68,3 +71,4 @@ runs:
         DEB_DISTRO: ${{ inputs.DEB_DISTRO }}
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         SQUASH_HISTORY: ${{ inputs.SQUASH_HISTORY }}
+        PACKAGES_BRANCH: ${{ inputs.PACKAGES_BRANCH }}

--- a/repository
+++ b/repository
@@ -36,19 +36,19 @@ apt-ftparchive release . > Release
 test -n "$GITHUB_TOKEN" && find . -type f -size +100M -delete
 
 REPOSITORY="$(printf "%s" "$GITHUB_REPOSITORY" | tr / _)"
-BRANCH="$DEB_DISTRO-$ROS_DISTRO"
+test -z "$PACKAGES_BRANCH" && PACKAGES_BRANCH="$DEB_DISTRO-$ROS_DISTRO"
 echo '```bash' > README.md
-echo "echo \"deb [trusted=yes] https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY.list" >> README.md
-echo "echo \"yaml https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$BRANCH/local.yaml $ROS_DISTRO\" | sudo tee /etc/ros/rosdep/sources.list.d/1-$REPOSITORY.list" >> README.md
+echo "echo \"deb [trusted=yes] https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$PACKAGES_BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY.list" >> README.md
+echo "echo \"yaml https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$PACKAGES_BRANCH/local.yaml $ROS_DISTRO\" | sudo tee /etc/ros/rosdep/sources.list.d/1-$REPOSITORY.list" >> README.md
 echo '```' >> README.md
 
 test -z "$GITHUB_TOKEN" && exit
 
-git init -b "$BRANCH"
+git init -b "$PACKAGES_BRANCH"
 git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 if [ "$SQUASH_HISTORY" != "true" ]; then
-  git fetch origin "$BRANCH" && git reset --soft FETCH_HEAD || true
+  git fetch origin "$PACKAGES_BRANCH" && git reset --soft FETCH_HEAD || true
 fi
 git add .
 git -c user.name=Github -c user.email=none commit --message="Generated from $(git -C .. rev-parse --short HEAD)"
-git push --force origin "$BRANCH"
+git push --force origin "$PACKAGES_BRANCH"

--- a/repository
+++ b/repository
@@ -36,19 +36,19 @@ apt-ftparchive release . > Release
 test -n "$GITHUB_TOKEN" && find . -type f -size +100M -delete
 
 REPOSITORY="$(printf "%s" "$GITHUB_REPOSITORY" | tr / _)"
-test -z "$PACKAGES_BRANCH" && PACKAGES_BRANCH="$DEB_DISTRO-$ROS_DISTRO"
+BRANCH="${PACKAGES_BRANCH:-$DEB_DISTRO-$ROS_DISTRO}"
 echo '```bash' > README.md
-echo "echo \"deb [trusted=yes] https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$PACKAGES_BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY.list" >> README.md
-echo "echo \"yaml https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$PACKAGES_BRANCH/local.yaml $ROS_DISTRO\" | sudo tee /etc/ros/rosdep/sources.list.d/1-$REPOSITORY.list" >> README.md
+echo "echo \"deb [trusted=yes] https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY.list" >> README.md
+echo "echo \"yaml https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$BRANCH/local.yaml $ROS_DISTRO\" | sudo tee /etc/ros/rosdep/sources.list.d/1-$REPOSITORY.list" >> README.md
 echo '```' >> README.md
 
 test -z "$GITHUB_TOKEN" && exit
 
-git init -b "$PACKAGES_BRANCH"
+git init -b "$BRANCH"
 git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 if [ "$SQUASH_HISTORY" != "true" ]; then
-  git fetch origin "$PACKAGES_BRANCH" && git reset --soft FETCH_HEAD || true
+  git fetch origin "$BRANCH" && git reset --soft FETCH_HEAD || true
 fi
 git add .
 git -c user.name=Github -c user.email=none commit --message="Generated from $(git -C .. rev-parse --short HEAD)"
-git push --force origin "$PACKAGES_BRANCH"
+git push --force origin "$BRANCH"


### PR DESCRIPTION
This PR adds a new option (`PACKAGES_BRANCH`) that lets users specificy where to push the generated packages to.