### PR TITLE
configurable architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Convert ROS packages to Debian packages.
 
 **Required** The Debian/Ubuntu distribution codename to compile for.
 
+## `DEB_ARCH`
+
+The architecture (`amd64`, `arm64`, ...) to compile for.
+
 ## `REPOS_FILE`
 
 Repos file with list of repositories to package.
@@ -77,13 +81,13 @@ jobs:
 
 You can run this action locally on Ubuntu 22.04 or Debian bookworm and newer system.
 
-Run `./prepare -d <deb_distro>` once to set up the system and/or adapt to your needs.
+Run `./prepare -d <deb_distro> -a <arch>` once to set up the system and/or adapt to your needs.
 It will create a `~/.cache/ccache` with sufficient rights for the sbuild process, a `~/.sbuildrc`, a `~/.cache/sbuild` and optionally a `./src` with the checked out repos.
 
-Run `./build -r <ros_distro> -d <deb_distro>` in a ROS workspace (or the current directory with `./src`) to generate the packages into the `apt_repo` folder.
+Run `./build -r <ros_distro> -d <deb_distro> -a <arch>` in a ROS workspace (or the current directory with `./src`) to generate the packages into the `apt_repo` folder.
 You can run `./build -c` to skip already built packages.
 
-Run `./repository -r <ros_distro> -d <deb_distro>` to create an apt repository.
+Run `./repository -r <ros_distro> -d <deb_distro> -a <arch>` to create an apt repository.
 You can directly use it on your local machine by adapting the path from the generated `README.md`.
 
 ## FAQ

--- a/action.yaml
+++ b/action.yaml
@@ -11,6 +11,9 @@ inputs:
   DEB_DISTRO:
     description: The Debian/Ubuntu distribution codename to compile for.
     required: true
+  DEB_ARCH:
+    description: The architecture (`amd64`, `arm64`, ...) to compile for.
+    required: false
   REPOS_FILE:
     description: Repos file with list of repositories to package.
     required: false
@@ -49,12 +52,13 @@ runs:
       uses: actions/cache@v3
       with:
         path: /home/runner/.cache/ccache
-        key: ccache-${{ inputs.DEB_DISTRO }}-${{ inputs.ROS_DISTRO }}
+        key: ccache-${{ inputs.DEB_DISTRO }}-${{ inputs.DEB_ARCH }}-${{ inputs.ROS_DISTRO }}
     - name: Setup build environment
       run: $GITHUB_ACTION_PATH/prepare
       shell: sh
       env:
         DEB_DISTRO: ${{ inputs.DEB_DISTRO }}
+        DEB_ARCH: ${{ inputs.DEB_ARCH }}
         REPOS_FILE: ${{ inputs.REPOS_FILE }}
         SBUILD_CONF: ${{ inputs.SBUILD_CONF }}
     - name: Create packages
@@ -63,6 +67,7 @@ runs:
       env:
         ROS_DISTRO: ${{ inputs.ROS_DISTRO }}
         DEB_DISTRO: ${{ inputs.DEB_DISTRO }}
+        DEB_ARCH: ${{ inputs.DEB_ARCH }}
         ROSDEP_SOURCE: ${{ inputs.ROSDEP_SOURCE }}
         SKIP_ROS_REPOSITORY: ${{ inputs.SKIP_ROS_REPOSITORY }}
         SKIP_PACKAGES: ${{ inputs.SKIP_PACKAGES }}
@@ -72,6 +77,7 @@ runs:
       env:
         ROS_DISTRO: ${{ inputs.ROS_DISTRO }}
         DEB_DISTRO: ${{ inputs.DEB_DISTRO }}
+        DEB_ARCH: ${{ inputs.DEB_ARCH }}
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         SQUASH_HISTORY: ${{ inputs.SQUASH_HISTORY == 'true' && 'true' || '' }}
         PACKAGES_BRANCH: ${{ inputs.PACKAGES_BRANCH }}

--- a/build
+++ b/build
@@ -4,7 +4,6 @@
 # defaults
 . /etc/os-release
 DEB_DISTRO="${DEB_DISTRO:-$VERSION_CODENAME}"
-DEB_ARCH="${DEB_ARCH:-$(dpkg --print-architecture)}"
 
 while getopts a:cd:hr: OPTCHAR; do
   case "$OPTCHAR" in
@@ -98,6 +97,8 @@ export DEB_BUILD_OPTIONS=nocheck
 TOTAL="$( (catkin_topological_order --only-names || colcon list --topological-order --names-only) | wc -l)"
 COUNT=1
 
+test -n "$DEB_ARCH" && set -- --arch="$DEB_ARCH" "$@"
+
 for PKG_PATH in $(catkin_topological_order --only-folders || colcon list --topological-order --paths-only); do
   echo "::group::Building $COUNT/$TOTAL: $PKG_PATH"
   (
@@ -122,7 +123,7 @@ for PKG_PATH in $(catkin_topological_order --only-folders || colcon list --topol
   echo 11 > debian/compat
 
   # dpkg-source-opts: no need for upstream.tar.gz
-  sbuild --chroot-mode=unshare --no-clean-source --no-run-lintian --arch="$DEB_ARCH" \
+  sbuild --chroot-mode=unshare --no-clean-source --no-run-lintian \
     --dpkg-source-opts="-Zgzip -z1 --format=1.0 -sn" --build-dir="$APT_REPO" \
     --extra-package="$APT_REPO" "$@"
 

--- a/build
+++ b/build
@@ -113,7 +113,7 @@ for PKG_PATH in $(catkin_topological_order --only-folders || colcon list --topol
   echo 11 > debian/compat
 
   # dpkg-source-opts: no need for upstream.tar.gz
-  sbuild --chroot-mode=unshare --no-clean-source --no-run-lintian \
+  sbuild --chroot-mode=unshare --no-clean-source --no-run-lintian --arch=arm64 \
     --dpkg-source-opts="-Zgzip -z1 --format=1.0 -sn" --build-dir="$APT_REPO" \
     --extra-package="$APT_REPO" "$@"
 

--- a/build
+++ b/build
@@ -1,8 +1,11 @@
 #!/bin/sh
 # SPDX-License-Identifier: BSD-3-Clause
 
-while getopts cd:hr: OPTCHAR; do
+while getopts a:cd:hr: OPTCHAR; do
   case "$OPTCHAR" in
+    a)
+      DEB_ARCH="$OPTARG"
+      ;;
     c)
       CONTINUE_PACKAGE_GENERATION=1
       ;;
@@ -10,7 +13,8 @@ while getopts cd:hr: OPTCHAR; do
       DEB_DISTRO="$OPTARG"
       ;;
     h)
-      echo "usage: $0 [-c]"
+      echo "usage: $0 [-a] [-c] [-d] [-r]"
+      echo "  -a The architecture to compile for."
       echo "  -c To continue at the last package and skip those already built."
       echo "  -d The Debian/Ubuntu distribution codename to compile for."
       echo "  -r The ROS distribution codename to compile for."
@@ -113,7 +117,7 @@ for PKG_PATH in $(catkin_topological_order --only-folders || colcon list --topol
   echo 11 > debian/compat
 
   # dpkg-source-opts: no need for upstream.tar.gz
-  sbuild --chroot-mode=unshare --no-clean-source --no-run-lintian --arch=arm64 \
+  sbuild --chroot-mode=unshare --no-clean-source --no-run-lintian --arch="$DEB_ARCH" \
     --dpkg-source-opts="-Zgzip -z1 --format=1.0 -sn" --build-dir="$APT_REPO" \
     --extra-package="$APT_REPO" "$@"
 

--- a/build
+++ b/build
@@ -1,6 +1,11 @@
 #!/bin/sh
 # SPDX-License-Identifier: BSD-3-Clause
 
+# defaults
+. /etc/os-release
+DEB_DISTRO="${DEB_DISTRO:-$VERSION_CODENAME}"
+DEB_ARCH="${DEB_ARCH:-$(dpkg --print-architecture)}"
+
 while getopts a:cd:hr: OPTCHAR; do
   case "$OPTCHAR" in
     a)

--- a/prepare
+++ b/prepare
@@ -1,13 +1,17 @@
 #!/bin/sh
 # SPDX-License-Identifier: BSD-3-Clause
 
-while getopts d:h OPTCHAR; do
+while getopts a:d:h OPTCHAR; do
   case "$OPTCHAR" in
+    a)
+      DEB_ARCH="$OPTARG"
+      ;;
     d)
       DEB_DISTRO="$OPTARG"
       ;;
     h)
-      echo "usage: $0 [-d]"
+      echo "usage: $0 [-a] [-d]"
+      echo "  -a To specify the architecture of the chroot."
       echo "  -d To specify the distribution of the chroot."
       exit
       ;;
@@ -39,9 +43,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuil
 echo "Setup build environment"
 
 mkdir -p "$HOME/.cache/sbuild"
-mmdebstrap --variant=buildd --include=apt,ccache,ca-certificates --arch=arm64 \
+mmdebstrap --variant=buildd --include=apt,ccache,ca-certificates --arch="$DEB_ARCH" \
   --customize-hook='chroot "$1" update-ccache-symlinks' \
-  --components=main,universe "$DEB_DISTRO" "$HOME/.cache/sbuild/$DEB_DISTRO-amd64.tar"
+  --components=main,universe "$DEB_DISTRO" "$HOME/.cache/sbuild/$DEB_DISTRO-$DEB_ARCH.tar"
 
 ccache --zero-stats --max-size=10.0G
 

--- a/prepare
+++ b/prepare
@@ -1,6 +1,11 @@
 #!/bin/sh
 # SPDX-License-Identifier: BSD-3-Clause
 
+# defaults
+. /etc/os-release
+DEB_DISTRO="${DEB_DISTRO:-$VERSION_CODENAME}"
+DEB_ARCH="${DEB_ARCH:-$(dpkg --print-architecture)}"
+
 while getopts a:d:h OPTCHAR; do
   case "$OPTCHAR" in
     a)
@@ -28,7 +33,7 @@ echo "Install dependencies"
 set -ex
 
 # TODO: drop once new distros are available
-test "$(lsb_release -cs)" = "jammy" && sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/sbuild
+test "$VERSION_CODENAME" = "jammy" && sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/sbuild
 sudo apt update
 
 # Try different package combinations:

--- a/prepare
+++ b/prepare
@@ -33,7 +33,7 @@ echo "Install dependencies"
 set -ex
 
 # TODO: drop once new distros are available
-test "$VERSION_CODENAME" = "jammy" && sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/sbuild
+test "$VERSION_CODENAME" = "jammy" && sudo apt install -y software-properties-common && sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/sbuild
 sudo apt update
 
 # Try different package combinations:

--- a/prepare
+++ b/prepare
@@ -36,7 +36,17 @@ set -ex
 test "$VERSION_CODENAME" = "jammy" && sudo apt install -y software-properties-common && sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/sbuild
 sudo apt update
 
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap curl git-lfs qemu-user-static arch-test
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap curl git-lfs
+
+if [ "$DEB_ARCH" != "$(dpkg --print-architecture)" ]; then
+  # use qemu to translate architecture
+  sudo apt install -y --no-install-recommends qemu-user-static arch-test
+  if [ "$VERSION_CODENAME" = "jammy" ]; then
+    # manally enable binfmt_misc on Ubuntu 22.04 Docker images
+    sudo apt install -y --no-install-recommends binfmt-support
+    arch-test "$DEB_ARCH" || sudo update-binfmts --enable
+  fi
+fi
 
 # Try different package combinations:
 # first is for a clean jammy with the PPA

--- a/prepare
+++ b/prepare
@@ -36,14 +36,16 @@ set -ex
 test "$VERSION_CODENAME" = "jammy" && sudo apt install -y software-properties-common && sudo add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/sbuild
 sudo apt update
 
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap curl git-lfs qemu-user-static arch-test
+
 # Try different package combinations:
 # first is for a clean jammy with the PPA
 # second is for Debian bookworm and newer
 # third is for OSRF package names
 # TODO: get OSRF to add proper package relations
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap vcstool python3-rosdep2 catkin python3-bloom curl git-lfs qemu-user-static arch-test || \
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap vcstool python3-rosdep2 colcon python3-colcon-package-information python3-colcon-ros python3-bloom curl git-lfs || \
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap python3-vcstool python3-rosdep python3-colcon-cmake python3-colcon-installed-package-information python3-colcon-library-path python3-colcon-package-information python3-colcon-pkg-config python3-colcon-recursive-crawl python3-colcon-test-result python3-bloom curl git-lfs
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends vcstool python3-rosdep2 catkin python3-bloom || \
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends vcstool python3-rosdep2 colcon python3-colcon-package-information python3-colcon-ros python3-bloom || \
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends python3-vcstool python3-rosdep python3-colcon-cmake python3-colcon-installed-package-information python3-colcon-library-path python3-colcon-package-information python3-colcon-pkg-config python3-colcon-recursive-crawl python3-colcon-test-result python3-bloom
 
 echo "Setup build environment"
 

--- a/prepare
+++ b/prepare
@@ -32,14 +32,14 @@ sudo apt update
 # second is for Debian bookworm and newer
 # third is for OSRF package names
 # TODO: get OSRF to add proper package relations
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap vcstool python3-rosdep2 catkin python3-bloom curl git-lfs || \
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap vcstool python3-rosdep2 catkin python3-bloom curl git-lfs qemu-user-static arch-test || \
 sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap vcstool python3-rosdep2 colcon python3-colcon-package-information python3-colcon-ros python3-bloom curl git-lfs || \
 sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends sbuild mmdebstrap distro-info debian-archive-keyring ccache uidmap python3-vcstool python3-rosdep python3-colcon-cmake python3-colcon-installed-package-information python3-colcon-library-path python3-colcon-package-information python3-colcon-pkg-config python3-colcon-recursive-crawl python3-colcon-test-result python3-bloom curl git-lfs
 
 echo "Setup build environment"
 
 mkdir -p "$HOME/.cache/sbuild"
-mmdebstrap --variant=buildd --include=apt,ccache,ca-certificates \
+mmdebstrap --variant=buildd --include=apt,ccache,ca-certificates --arch=arm64 \
   --customize-hook='chroot "$1" update-ccache-symlinks' \
   --components=main,universe "$DEB_DISTRO" "$HOME/.cache/sbuild/$DEB_DISTRO-amd64.tar"
 

--- a/repository
+++ b/repository
@@ -1,6 +1,11 @@
 #!/bin/sh
 # SPDX-License-Identifier: BSD-3-Clause
 
+# defaults
+. /etc/os-release
+DEB_DISTRO="${DEB_DISTRO:-$VERSION_CODENAME}"
+DEB_ARCH="${DEB_ARCH:-$(dpkg --print-architecture)}"
+
 while getopts a:d:hr: OPTCHAR; do
   case "$OPTCHAR" in
     a)

--- a/repository
+++ b/repository
@@ -36,7 +36,7 @@ apt-ftparchive release . > Release
 test -n "$GITHUB_TOKEN" && find . -type f -size +100M -delete
 
 REPOSITORY="$(printf "%s" "$GITHUB_REPOSITORY" | tr / _)"
-BRANCH="${PACKAGES_BRANCH:-$DEB_DISTRO-$ROS_DISTRO}"
+BRANCH="${PACKAGES_BRANCH:-$DEB_DISTRO-$ROS_DISTRO}-arm64"
 echo '```bash' > README.md
 echo "echo \"deb [trusted=yes] $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/raw/$BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY.list" >> README.md
 echo "echo \"yaml $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/raw/$BRANCH/local.yaml $ROS_DISTRO\" | sudo tee /etc/ros/rosdep/sources.list.d/1-$REPOSITORY.list" >> README.md

--- a/repository
+++ b/repository
@@ -1,13 +1,17 @@
 #!/bin/sh
 # SPDX-License-Identifier: BSD-3-Clause
 
-while getopts d:hr: OPTCHAR; do
+while getopts a:d:hr: OPTCHAR; do
   case "$OPTCHAR" in
+    a)
+      DEB_ARCH="$OPTCHAR"
+      ;;
     d)
       DEB_DISTRO="$OPTARG"
       ;;
     h)
-      echo "usage: $0 [-c]"
+      echo "usage: $0 [-a] [-d] [-r]"
+      echo "  -a The architecture to compile for."
       echo "  -d The Debian/Ubuntu distribution codename to compile for."
       echo "  -r The ROS distribution codename to compile for."
       exit
@@ -36,7 +40,7 @@ apt-ftparchive release . > Release
 test -n "$GITHUB_TOKEN" && find . -type f -size +100M -delete
 
 REPOSITORY="$(printf "%s" "$GITHUB_REPOSITORY" | tr / _)"
-BRANCH="${PACKAGES_BRANCH:-$DEB_DISTRO-$ROS_DISTRO}-arm64"
+BRANCH="${PACKAGES_BRANCH:-$DEB_DISTRO-$ROS_DISTRO}-${DEB_ARCH}"
 echo '```bash' > README.md
 echo "echo \"deb [trusted=yes] $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/raw/$BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY.list" >> README.md
 echo "echo \"yaml $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/raw/$BRANCH/local.yaml $ROS_DISTRO\" | sudo tee /etc/ros/rosdep/sources.list.d/1-$REPOSITORY.list" >> README.md


### PR DESCRIPTION
This makes the architecture of the target configurable. If the target architecture does not match the host architecture, qemu is used to translate.

I am adding a couple of fixes to make this a bit more robust on the CI.

This is based on https://github.com/jspricke/ros-deb-builder-action/commits/arm64/ (and obsoletes this branch) and fixes https://github.com/jspricke/ros-deb-builder-action/issues/42.