### PR TITLE
fix checkout evaluation

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ runs:
   steps:
     - name: Check out the repo
       uses: actions/checkout@v3
-      if: ${{ inputs.SKIP_CHECKOUT == 'true' && 'true' || '' }}
+      if: ${{ inputs.SKIP_CHECKOUT == 'false' }}
     - name: Cache ccache
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
Fixes https://github.com/jspricke/ros-deb-builder-action/pull/47#issuecomment-2094938648.

Works now with `SKIP_CHECKOUT` unset and set to `false` and `true`.