### PR TITLE
Drop catkin as colcon builds ROS1 just fine

### DIFF
--- a/build
+++ b/build
@@ -81,7 +81,7 @@ echo "Add unreleased packages to rosdep"
 
 set -ex
 
-for PKG in $(catkin_topological_order --only-names || colcon list --topological-order --names-only); do
+for PKG in $(colcon list --topological-order --names-only); do
   printf "%s:\n  %s:\n  - %s\n" "$PKG" "$DISTRIBUTION" "ros-$ROS_DEB$(printf '%s' "$PKG" | tr '_' '-')" >> "$APT_REPO/local.yaml"
 done
 echo "yaml file://$APT_REPO/local.yaml $ROS_DISTRO" > "$APT_REPO/1-local.list"
@@ -94,16 +94,16 @@ echo "Run sbuild"
 # Don't build tests
 export DEB_BUILD_OPTIONS=nocheck
 
-TOTAL="$( (catkin_topological_order --only-names || colcon list --topological-order --names-only) | wc -l)"
+TOTAL="$( (colcon list --topological-order --names-only) | wc -l)"
 COUNT=1
 
 test -n "$DEB_ARCH" && set -- --arch="$DEB_ARCH" "$@"
 
-for PKG_PATH in $(catkin_topological_order --only-folders || colcon list --topological-order --paths-only); do
+for PKG_PATH in $(colcon list --topological-order --paths-only); do
   echo "::group::Building $COUNT/$TOTAL: $PKG_PATH"
   (
   cd "$PKG_PATH"
-  ROS_PACKAGE="$(catkin_topological_order --only-names || colcon list --topological-order --names-only)"
+  ROS_PACKAGE="$(colcon list --topological-order --names-only)"
   test -f "$PKG_PATH/CATKIN_IGNORE" && echo "$ROS_PACKAGE Skipped (CATKIN_IGNORE)" && exit
   test -f "$PKG_PATH/COLCON_IGNORE" && echo "$ROS_PACKAGE Skipped (COLCON_IGNORE)" && exit
   case " $SKIP_PACKAGES " in *" $ROS_PACKAGE "*) echo "$ROS_PACKAGE Skipped (in \$SKIP_PACKAGES)"; exit ;; esac

--- a/prepare
+++ b/prepare
@@ -42,7 +42,7 @@ if [ "$DEB_ARCH" != "$(dpkg --print-architecture)" ]; then
   # use qemu to translate architecture
   sudo apt install -y --no-install-recommends qemu-user-static arch-test
   if [ "$VERSION_CODENAME" = "jammy" ]; then
-    # manally enable binfmt_misc on Ubuntu 22.04 Docker images
+    # manually enable binfmt_misc on Ubuntu 22.04 Docker images
     sudo apt install -y --no-install-recommends binfmt-support
     arch-test "$DEB_ARCH" || sudo update-binfmts --enable
   fi
@@ -53,7 +53,7 @@ fi
 # second is for Debian bookworm and newer
 # third is for OSRF package names
 # TODO: get OSRF to add proper package relations
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends vcstool python3-rosdep2 catkin python3-bloom || \
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends vcstool python3-rosdep2 python3-bloom || \
 sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends vcstool python3-rosdep2 colcon python3-colcon-package-information python3-colcon-ros python3-bloom || \
 sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends python3-vcstool python3-rosdep python3-colcon-cmake python3-colcon-installed-package-information python3-colcon-library-path python3-colcon-package-information python3-colcon-pkg-config python3-colcon-recursive-crawl python3-colcon-test-result python3-bloom
 


### PR DESCRIPTION
While debugging I noticed some fallbacks to colcon which are not required.

Colcon builds ROS1 just fine, also saves a dependency.