### PR TITLE
fix: increase DlMaxRetries to avoid issues when downloading packages

### DIFF
--- a/prepare
+++ b/prepare
@@ -50,6 +50,7 @@ fi
 
 sudo mkdir /etc/apt-cacher-ng
 echo 'VfileUseRangeOps: 0' | sudo tee /etc/apt-cacher-ng/zzz_override.conf
+echo 'DlMaxRetries: 200' | sudo tee -a /etc/apt-cacher-ng/zzz_override.conf
 
 # Try different package combinations:
 # first is for Debian bookworm and newer resp. Ubuntu noble with the PPA


### PR DESCRIPTION
I'm getting multiple 503 errors when using `apt-cacher-ng`, like the following:

```
...
  Err:139 http://archive.ubuntu.com/ubuntu jammy/main amd64 libarchive-zip-perl all 1.68-1
    503  Connection closed, check DlMaxRetries [IP: 127.0.0.1 3142]
  Err:170 http://archive.ubuntu.com/ubuntu jammy/universe amd64 python3-pydocstyle all 6.1.1-1
    503  Connection closed, check DlMaxRetries [IP: 127.0.0.1 3142]
  Err:171 http://archive.ubuntu.com/ubuntu jammy/universe amd64 pydocstyle all 6.1.1-1
    503  Connection closed, check DlMaxRetries [IP: 127.0.0.1 3142]
  Err:172 http://archive.ubuntu.com/ubuntu jammy/universe amd64 python3-argcomplete all 1.8.1-1.5
    503  Connection closed, check DlMaxRetries [IP: 127.0.0.1 3142]
  Err:173 http://archive.ubuntu.com/ubuntu jammy/main amd64 python3-attr all 21.2.0-1
    503  Connection closed, check DlMaxRetries [IP: 127.0.0.1 3142]
  Err:174 http://archive.ubuntu.com/ubuntu jammy/main amd64 python3-six all 1.16.0-3ubuntu1
    503  Connection closed, check DlMaxRetries [IP: 127.0.0.1 3142]
  Err:175 http://archive.ubuntu.com/ubuntu jammy/main amd64 python3-dateutil all 2.8.1-6
    503  Connection closed, check DlMaxRetries [IP: 127.0.0.1 3142]
  Err:176 http://archive.ubuntu.com/ubuntu jammy/main amd64 python3-roman all 3.3-1
    503  Connection closed, check DlMaxRetries [IP: 127.0.0.1 3142]
...
```

According to https://bugs.launchpad.net/ubuntu/+source/apt-cacher-ng/+bug/1826405 one fix for this is to increase the value of `DlMaxRetries`

Edit: I meant https://bugs.launchpad.net/ubuntu/+source/apt-cacher-ng/+bug/1960264