### PR TITLE
fix: disable apt-cacher-ng again

### DIFF
--- a/prepare
+++ b/prepare
@@ -48,24 +48,20 @@ if [ "$DEB_ARCH" != "$(dpkg --print-architecture)" ]; then
   fi
 fi
 
-sudo mkdir /etc/apt-cacher-ng
-echo 'VfileUseRangeOps: 0' | sudo tee /etc/apt-cacher-ng/zzz_override.conf
-
 # Try different package combinations:
 # first is for Debian bookworm and newer resp. Ubuntu noble with the PPA
 # second is for a clean Ubuntu jammy with the PPA
 # third is for OSRF package names
 # TODO: get OSRF to add proper package relations
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends apt-cacher-ng vcstool python3-rosdep2 colcon python3-colcon-package-information python3-colcon-ros python3-bloom python3-colcon-defaults python3-colcon-package-selection || \
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends apt-cacher-ng vcstool python3-rosdep2 catkin python3-bloom || \
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends apt-cacher-ng python3-vcstool python3-rosdep python3-colcon-cmake python3-colcon-installed-package-information python3-colcon-library-path python3-colcon-package-information python3-colcon-pkg-config python3-colcon-recursive-crawl python3-colcon-test-result python3-colcon-defaults python3-colcon-package-selection python3-bloom
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends vcstool python3-rosdep2 colcon python3-colcon-package-information python3-colcon-ros python3-bloom python3-colcon-defaults python3-colcon-package-selection || \
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends vcstool python3-rosdep2 catkin python3-bloom || \
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends python3-vcstool python3-rosdep python3-colcon-cmake python3-colcon-installed-package-information python3-colcon-library-path python3-colcon-package-information python3-colcon-pkg-config python3-colcon-recursive-crawl python3-colcon-test-result python3-colcon-defaults python3-colcon-package-selection python3-bloom
 
 echo "Setup build environment"
 
 mkdir -p "$HOME/.cache/sbuild"
 mmdebstrap --variant=buildd --include=apt,ccache,ca-certificates --arch="$DEB_ARCH" \
   --customize-hook='chroot "$1" update-ccache-symlinks' \
-  --aptopt='Acquire::http { Proxy "http://127.0.0.1:3142"; }' \
   --components=main,universe "$DEB_DISTRO" "$HOME/.cache/sbuild/$DEB_DISTRO-$DEB_ARCH.tar"
 
 ccache --zero-stats --max-size=10.0G


### PR DESCRIPTION
See https://github.com/jspricke/ros-deb-builder-action/pull/66#issuecomment-2789398660