### PR TITLE
add colcon-ros extension when using OSRF packages

### DIFF
--- a/prepare
+++ b/prepare
@@ -55,7 +55,7 @@ fi
 # TODO: get OSRF to add proper package relations
 sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends vcstool python3-rosdep2 colcon python3-colcon-package-information python3-colcon-ros python3-bloom python3-colcon-defaults python3-colcon-package-selection || \
 sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends vcstool python3-rosdep2 catkin python3-bloom || \
-sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends python3-vcstool python3-rosdep python3-colcon-cmake python3-colcon-installed-package-information python3-colcon-library-path python3-colcon-package-information python3-colcon-pkg-config python3-colcon-recursive-crawl python3-colcon-test-result python3-colcon-defaults python3-colcon-package-selection python3-bloom
+sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends python3-vcstool python3-rosdep python3-colcon-cmake python3-colcon-installed-package-information python3-colcon-library-path python3-colcon-package-information python3-colcon-pkg-config python3-colcon-recursive-crawl python3-colcon-ros python3-colcon-test-result python3-colcon-defaults python3-colcon-package-selection python3-bloom
 
 echo "Setup build environment"
 


### PR DESCRIPTION
This PR installs the `colcon-ros` extension so that `package.xml` parsing works, otherwise things like `packages-skip-by-dep` don't work in `COLCON_DEFAULTS_FILE`