### PR TITLE
use absolute workspace path "/tmp/ws/"

### DIFF
--- a/build
+++ b/build
@@ -37,9 +37,9 @@ done
 shift "$((OPTIND - 1))"
 
 # make output directory
-test -z "$CONTINUE_PACKAGE_GENERATION" && rm -rf apt_repo
-mkdir -p apt_repo
-APT_REPO="$(pwd)/apt_repo"
+APT_REPO="/tmp/apt_repo/"
+test -z "$CONTINUE_PACKAGE_GENERATION" && rm -rf "$APT_REPO"
+mkdir -p "$APT_REPO"
 
 if [ -z "$DISTRIBUTION" ]; then
   if debian-distro-info --all | grep -q "$DEB_DISTRO"; then

--- a/build
+++ b/build
@@ -4,6 +4,7 @@
 # defaults
 . /etc/os-release
 DEB_DISTRO="${DEB_DISTRO:-$VERSION_CODENAME}"
+WS_PATH="/tmp/ws/"
 
 while getopts a:cd:hr: OPTCHAR; do
   case "$OPTCHAR" in
@@ -81,7 +82,7 @@ echo "Add unreleased packages to rosdep"
 
 set -ex
 
-for PKG in $(colcon list --topological-order --names-only || catkin_topological_order --only-names); do
+for PKG in $(colcon list --base-paths "$WS_PATH" --topological-order --names-only || catkin_topological_order --only-names); do
   printf "%s:\n  %s:\n  - %s\n" "$PKG" "$DISTRIBUTION" "ros-$ROS_DEB$(printf '%s' "$PKG" | tr '_' '-')" >> "$APT_REPO/local.yaml"
 done
 echo "yaml file://$APT_REPO/local.yaml $ROS_DISTRO" > "$APT_REPO/1-local.list"
@@ -94,16 +95,16 @@ echo "Run sbuild"
 # Don't build tests
 export DEB_BUILD_OPTIONS=nocheck
 
-TOTAL="$( (colcon list --topological-order --names-only || catkin_topological_order --only-names) | wc -l)"
+TOTAL="$( (colcon list --base-paths "$WS_PATH" --topological-order --names-only || catkin_topological_order --only-names) | wc -l)"
 COUNT=1
 
 test -n "$DEB_ARCH" && set -- --arch="$DEB_ARCH" "$@"
 
-for PKG_PATH in $(colcon list --topological-order --paths-only || catkin_topological_order --only-folders); do
+for PKG_PATH in $(colcon list --base-paths "$WS_PATH" --topological-order --paths-only || catkin_topological_order --only-folders); do
   echo "::group::Building $COUNT/$TOTAL: $PKG_PATH"
   (
   cd "$PKG_PATH"
-  ROS_PACKAGE="$(COLCON_DEFAULTS_FILE="" colcon list --topological-order --names-only || catkin_topological_order --only-names)"
+  ROS_PACKAGE="$(COLCON_DEFAULTS_FILE="" colcon list --base-paths "$WS_PATH" --topological-order --names-only || catkin_topological_order --only-names)"
   test -f "$PKG_PATH/CATKIN_IGNORE" && echo "$ROS_PACKAGE Skipped (CATKIN_IGNORE)" && exit
   test -f "$PKG_PATH/COLCON_IGNORE" && echo "$ROS_PACKAGE Skipped (COLCON_IGNORE)" && exit
   case " $SKIP_PACKAGES " in *" $ROS_PACKAGE "*) echo "$ROS_PACKAGE Skipped (in \$SKIP_PACKAGES)"; exit ;; esac

--- a/prepare
+++ b/prepare
@@ -5,6 +5,7 @@
 . /etc/os-release
 DEB_DISTRO="${DEB_DISTRO:-$VERSION_CODENAME}"
 DEB_ARCH="${DEB_ARCH:-$(dpkg --print-architecture)}"
+WS_PATH="/tmp/ws/"
 
 while getopts a:d:h OPTCHAR; do
   case "$OPTCHAR" in
@@ -85,5 +86,5 @@ REPOS_FILE="${REPOS_FILE:-sources.repos}"
 
 echo "Checkout workspace"
 
-mkdir src
-vcs import --recursive --input  "$REPOS_FILE" src
+mkdir -p "$WS_PATH"
+vcs import --recursive --input  "$REPOS_FILE" "$WS_PATH"

--- a/repository
+++ b/repository
@@ -5,6 +5,7 @@
 . /etc/os-release
 DEB_DISTRO="${DEB_DISTRO:-$VERSION_CODENAME}"
 DEB_ARCH="${DEB_ARCH:-$(dpkg --print-architecture)}"
+WS_PATH="/tmp/ws/"
 
 while getopts a:d:hr: OPTCHAR; do
   case "$OPTCHAR" in
@@ -34,7 +35,7 @@ shift "$((OPTIND - 1))"
 
 set -ex
 
-test -d src && vcs export src --exact-with-tags > apt_repo/sources.repos
+test -d "$WS_PATH" && vcs export "$WS_PATH" --exact-with-tags > apt_repo/sources.repos
 
 cd apt_repo
 

--- a/repository
+++ b/repository
@@ -6,6 +6,7 @@
 DEB_DISTRO="${DEB_DISTRO:-$VERSION_CODENAME}"
 DEB_ARCH="${DEB_ARCH:-$(dpkg --print-architecture)}"
 WS_PATH="/tmp/ws/"
+APT_REPO="/tmp/apt_repo/"
 
 while getopts a:d:hr: OPTCHAR; do
   case "$OPTCHAR" in
@@ -35,9 +36,9 @@ shift "$((OPTIND - 1))"
 
 set -ex
 
-test -d "$WS_PATH" && vcs export "$WS_PATH" --exact-with-tags > apt_repo/sources.repos
+test -d "$WS_PATH" && vcs export "$WS_PATH" --exact-with-tags > "$APT_REPO/sources.repos"
 
-cd apt_repo
+cd "$APT_REPO"
 
 apt-ftparchive packages . > Packages
 apt-ftparchive release . > Release


### PR DESCRIPTION
This checks out the workspace to `/tmp/ws/` instead of relative to the current working directory to avoid issues with vcs.

Fixes #69.