### PR TITLE
suffix "$BRANCH" to repo files to avoid overriding with multiple branches

### DIFF
--- a/repository
+++ b/repository
@@ -49,12 +49,12 @@ BRANCH="${PACKAGES_BRANCH:-$DEB_DISTRO-$ROS_DISTRO-$DEB_ARCH}"
 echo '```bash' > README.md
 
 if [ "$GITHUB_SERVER_URL" = "https://github.com" ]; then
-  echo "echo \"deb [trusted=yes] https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY.list" >> README.md
+  echo "echo \"deb [trusted=yes] https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY-$BRANCH.list" >> README.md
 else
-  echo "echo \"deb [trusted=yes] $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/raw/$BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY.list" >> README.md
+  echo "echo \"deb [trusted=yes] $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/raw/$BRANCH/ ./\" | sudo tee /etc/apt/sources.list.d/$REPOSITORY-$BRANCH.list" >> README.md
 fi
 
-echo "echo \"yaml $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/raw/$BRANCH/local.yaml $ROS_DISTRO\" | sudo tee /etc/ros/rosdep/sources.list.d/1-$REPOSITORY.list" >> README.md
+echo "echo \"yaml $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/raw/$BRANCH/local.yaml $ROS_DISTRO\" | sudo tee /etc/ros/rosdep/sources.list.d/1-$REPOSITORY-$BRANCH.list" >> README.md
 echo '```' >> README.md
 
 test -z "$GITHUB_TOKEN" && exit


### PR DESCRIPTION
When using multiple actions in the same repo, they will all suggest setting the apt and rosdep repo files to the same name. Hence, when you want to use packages from multiple branches of the same repo at the same time, the instructions will override each other.

Append the `$BRANCH` to both files to avoid this overriding.