### PR TITLE
remove hard-coded file size limit

### DIFF
--- a/repository
+++ b/repository
@@ -41,9 +41,6 @@ cd apt_repo
 apt-ftparchive packages . > Packages
 apt-ftparchive release . > Release
 
-# Github size limit
-test -n "$GITHUB_TOKEN" && find . -type f -size +100M -delete
-
 REPOSITORY="$(printf "%s" "$GITHUB_REPOSITORY" | tr / _)"
 BRANCH="${PACKAGES_BRANCH:-$DEB_DISTRO-$ROS_DISTRO-$DEB_ARCH}"
 echo '```bash' > README.md


### PR DESCRIPTION
This removes the hard-coded file size limit of 100MB in the script. IMHO, the script should rather fail to inform the user of this issue, than silently removing files. Also, other GitHub instances will have different file size limits.