### PR TITLE
optionally use the ROS 2 testing repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Convert ROS packages to Debian packages.
 
 **Required** The ROS distribution codename to compile for.
 
+## `ROS_TESTING`
+
+`true`: Use the [ros-testing repository](https://docs.ros.org/en/rolling/Installation/Testing.html) (default: `false`).
+
 ## `DEB_DISTRO`
 
 **Required** The Debian/Ubuntu distribution codename to compile for.

--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,10 @@ inputs:
   ROS_DISTRO:
     description: The ROS distribution codename to compile for.
     required: true
+  ROS_TESTING:
+    description: Use the ros-testing repository.
+    required: false
+    default: false
   DEB_DISTRO:
     description: The Debian/Ubuntu distribution codename to compile for.
     required: true
@@ -76,6 +80,7 @@ runs:
       shell: sh
       env:
         ROS_DISTRO: ${{ inputs.ROS_DISTRO }}
+        ROS_TESTING: ${{ inputs.ROS_TESTING }}
         DEB_DISTRO: ${{ inputs.DEB_DISTRO }}
         DEB_ARCH: ${{ inputs.DEB_ARCH }}
         ROSDEP_SOURCE: ${{ inputs.ROSDEP_SOURCE }}

--- a/build
+++ b/build
@@ -71,8 +71,12 @@ case $ROS_DISTRO in
     BLOOM=ros
     ROS_DEB="$ROS_DISTRO-"
     if [ -z "$SKIP_ROS_REPOSITORY" ]; then
-      curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o "$APT_REPO/ros-archive-keyring.gpg"
-      set -- --extra-repository="deb http://packages.ros.org/ros2/ubuntu $DEB_DISTRO main" --extra-repository-key="$APT_REPO/ros-archive-keyring.gpg" "$@"
+      curl -sSL https://github.com/ros-infrastructure/ros-apt-source/raw/refs/heads/main/ros-apt-source/keys/ros2-archive-keyring.gpg -o "$APT_REPO/ros2-archive-keyring.gpg"
+      if [ "$ROS_TESTING" = "false" ]; then
+        set -- --extra-repository="deb http://packages.ros.org/ros2/ubuntu $DEB_DISTRO main" --extra-repository-key="$APT_REPO/ros2-archive-keyring.gpg" "$@"
+      elif [ "$ROS_TESTING" = "true" ]; then
+        set -- --extra-repository="deb http://packages.ros.org/ros2-testing/ubuntu $DEB_DISTRO main" --extra-repository-key="$APT_REPO/ros2-archive-keyring.gpg" "$@"
+      fi
     fi
     ;;
 esac


### PR DESCRIPTION
Add new boolean option `ROS_TESTING` to use the [ROS 2 testing repo](https://docs.ros.org/en/rolling/Installation/Testing.html).

This also replaces the PPA with the [official repo](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html#enable-required-repositories) and installation instructions for the `ros-dev-tools` in order to simplify the code and avoid recent issues with PPAs.

Fixes: #76 